### PR TITLE
Allow the usage of AWS Credentials objects.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,11 +7,18 @@ module.exports = function (options) {
 
   var cloudfront = new aws.CloudFront();
 
-  cloudfront.config.update({
-    accessKeyId: options.accessKeyId || process.env.AWS_ACCESS_KEY_ID,
-    secretAccessKey: options.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY,
-    sessionToken: options.sessionToken || process.env.AWS_SESSION_TOKEN
-  });
+  if ('credentials' in options) {
+    cloudfront.config.update({
+      credentials: options.credentials
+    });
+  }
+  else {
+    cloudfront.config.update({
+      accessKeyId: options.accessKeyId || process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: options.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY,
+      sessionToken: options.sessionToken || process.env.AWS_SESSION_TOKEN
+    });
+  }
 
   var complain = function (err, msg, callback) {
     return callback(new util.PluginError('gulp-cloudfront-invalidate', msg + ': ' + err));


### PR DESCRIPTION
Instead of loading AWS credentials manually or putting them in environment variables, they can be loaded [any way that the AWS SDK supports](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Credentials.html).

e.g.:

``` js
var awsCredentials = new AWS.SharedIniFileCredentials({profile: 'myprofile'});
var cloudflareSettings = {
    credentials: awsCredentials,
    distribution: 'my_cf_dist'
};
```

instead of

``` js
var cloudflareSettings = {
    accessKeyId: '...',
    secretAccessKey: '...',
    sessionToken: '...',
    distribution: 'my_cf_dist'
};
```

thanks for this plugin!
