### PR TITLE
Replace gulp-util with individual modules (Close #5)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-var util = require('gulp-util')
+var log = require('fancy-log')
+  , PluginError = require('plugin-error')
   , through = require('through2')
   , aws = require('aws-sdk');
 
@@ -21,7 +22,7 @@ module.exports = function (options) {
   }
 
   var complain = function (err, msg, callback) {
-    return callback(new util.PluginError('gulp-cloudfront-invalidate', msg + ': ' + err));
+    return callback(new PluginError('gulp-cloudfront-invalidate', msg + ': ' + err));
   };
 
   var check = function (id, callback) {
@@ -54,7 +55,7 @@ module.exports = function (options) {
     }, function (err, res) {
       if (err) return complain(err, 'Could not invalidate cloudfront', callback);
 
-      util.log('Cloudfront invalidation created: ' + res.Invalidation.Id);
+      log('Cloudfront invalidation created: ' + res.Invalidation.Id);
 
       if (!options.wait) {
         return callback();

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   ],
   "dependencies": {
     "aws-sdk": "2.1.x",
-    "gulp-util": "3.0.x",
+    "fancy-log": "1.3.x",
+    "plugin-error": "1.0.x",
     "through2": "2.0.x"
   },
   "bugs": {


### PR DESCRIPTION
See https://github.com/confyio/gulp-cloudfront-invalidate/issues/5 for more details about the migration.