### PR TITLE
Fix https://www.npmjs.com/advisories/1005356

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "invalidation"
   ],
   "dependencies": {
-    "aws-sdk": "2.1.x",
+    "aws-sdk": "2.814.x",
     "fancy-log": "1.3.x",
     "plugin-error": "1.0.x",
     "through2": "2.0.x"


### PR DESCRIPTION
The current version is causing npm audit warnings with high severity because of an outdated aws-sdk version.  See https://github.com/advisories/GHSA-rrc9-gqf8-8rwg.  This update should resolve the audit warnings.